### PR TITLE
Fixing PHP Warning on Accessing "children" Property

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -101,9 +101,11 @@ function local_learning_analytics_extend_navigation(global_navigation $navigatio
         $beforekey = null;
         if ($settingbeforekey === false || $settingbeforekey === '') {
             // Find first section node, and add our node before that (to be the last non-section node)
-            $children = $node->children->type(navigation_node::TYPE_SECTION);
-            if (count($children) !== 0) {
-                $beforekey = reset($children)->key;
+            if (is_object($node->children)) {
+                $children = $node->children->type(navigation_node::TYPE_SECTION);
+                if (count($children) !== 0) {
+                    $beforekey = reset($children)->key;
+                }
             }
         } else { // use setting
             $beforekey = $settingbeforekey;


### PR DESCRIPTION
I fixed an issue that caused a PHP warning when trying to access the "children" property on a boolean value. The error occurred due to an attempt to access a method on a variable that in some cases could be a boolean, instead of the expected object. For example, local_aiquestions couldn't work properly without this code change. So the check was added to ensure that $node->children is an object before attempting to access the type() method. This avoids the mentioned error and improves the stability and reliability of the code.